### PR TITLE
empty() made some problems - should work now

### DIFF
--- a/DiagnoseModules.module
+++ b/DiagnoseModules.module
@@ -166,5 +166,7 @@ class DiagnoseModules extends Wire implements Module, ConfigurableModule
 
     public function __set($a, $b) {}
 
-    public static function getModuleConfigInputfields(array $data) {}
+    public static function getModuleConfigInputfields(array $data) {
+        return array();
+    }
 }


### PR DESCRIPTION
Found it here: http://stackoverflow.com/questions/1075534/cant-use-method-return-value-in-write-context
